### PR TITLE
pcm-memory:mainloop: Always flush cout

### DIFF
--- a/src/pcm-memory.cpp
+++ b/src/pcm-memory.cpp
@@ -1238,7 +1238,7 @@ int main(int argc, char * argv[])
 
     mainLoop([&]()
     {
-        if(!csv) cout << flush;
+        cout << flush;
 
         calibratedSleep(delay, sysCmd, mainLoop, m);
 


### PR DESCRIPTION
Flushing cout in cvs mode is also useful when the output is a pipeline
using the values to display in real time. As such, always flush the cout
buffers at the start of the main loop.

Signed-off-by: Warner Losh <imp@FreeBSD.org>