### PR TITLE
Remove warnings in macOS build

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,10 +6,17 @@
 set(PROJECT_NAMES pcm pcm-numa pcm-latency pcm-power pcm-msr pcm-memory pcm-tsx pcm-pcie pcm-core pcm-iio pcm-lspci pcm-pcicfg pcm-mmio pcm-raw)
 
 file(GLOB COMMON_SOURCES msr.cpp cpucounters.cpp pci.cpp mmio.cpp bw.cpp utils.cpp topology.cpp debug.cpp threadpool.cpp)
-file(GLOB UNUX_SOURCES dashboard.cpp resctrl.cpp)
+
+if (APPLE)
+  file(GLOB UNUX_SOURCES dashboard.cpp)
+else()
+  file(GLOB UNUX_SOURCES dashboard.cpp resctrl.cpp)
+endif()
 
 if(UNIX)  # LINUX, FREE_BSD, APPLE
-    set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS} -s")  # --strip-unneeded for packaging
+    if (NOT APPLE)
+      set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS} -s")  # --strip-unneeded for packaging
+    endif()
 
     list(APPEND PROJECT_NAMES pcm-sensor)
     if(LINUX)

--- a/src/MacMSRDriver/MSRAccessor.cpp
+++ b/src/MacMSRDriver/MSRAccessor.cpp
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2012, Intel Corporation
 // written by Austen Ott
-//    
+//
 #include "MSRAccessor.h"
 #include <exception>
 MSRAccessor::MSRAccessor(){
-    service = IOServiceGetMatchingService(kIOMasterPortDefault, IOServiceMatching(kPcmMsrDriverClassName));
+    service = IOServiceGetMatchingService(kIOMainPortDefault,
+                                          IOServiceMatching(kPcmMsrDriverClassName));
     openConnection();
 }
 

--- a/src/MacMSRDriver/PCIDriverInterface.cpp
+++ b/src/MacMSRDriver/PCIDriverInterface.cpp
@@ -18,37 +18,40 @@ extern "C"
 #endif
 int PCIDriver_setupDriver()
 {
-	kern_return_t   kern_result;
-    io_iterator_t   iterator;
-    bool            driverFound = false;
-    io_service_t    local_driver_service;
-    
-	// get services
-    kern_result = IOServiceGetMatchingServices(kIOMasterPortDefault, IOServiceMatching(kPcmMsrDriverClassName), &iterator);
-	if (kern_result != KERN_SUCCESS) {
-		fprintf(stderr, "[error] IOServiceGetMatchingServices returned 0x%08x\n", kern_result);
-        return kern_result;
-    }
-	
-	// find service
-	while ((local_driver_service = IOIteratorNext(iterator)) != IO_OBJECT_NULL) {
-        driverFound = true;
-        break;
-    }
-	if (driverFound == false) {  
-        fprintf(stderr, "[error] No matching drivers found \"%s\".\n", kPcmMsrDriverClassName);
-        return KERN_FAILURE;
-    }
-	IOObjectRelease(iterator);
+     kern_return_t   kern_result;
+     io_iterator_t   iterator;
+     bool            driverFound = false;
+     io_service_t    local_driver_service;
 
-	// connect to service
-    kern_result = IOServiceOpen(local_driver_service, mach_task_self(), 0, &PCIDriver_connect);
-    if (kern_result != KERN_SUCCESS) {
-        fprintf(stderr, "[error] IOServiceOpen returned 0x%08x\n", kern_result);
-		return kern_result;
-    }
-	
-	return KERN_SUCCESS;
+     // get services
+     kern_result = IOServiceGetMatchingServices(kIOMainPortDefault,
+                                                IOServiceMatching(kPcmMsrDriverClassName),
+                                                &iterator);
+     if (kern_result != KERN_SUCCESS) {
+          fprintf(stderr, "[error] IOServiceGetMatchingServices returned 0x%08x\n", kern_result);
+          return kern_result;
+     }
+
+     // find service
+     while ((local_driver_service = IOIteratorNext(iterator)) != IO_OBJECT_NULL) {
+          driverFound = true;
+          break;
+     }
+
+     if (driverFound == false) {
+          fprintf(stderr, "[error] No matching drivers found \"%s\".\n", kPcmMsrDriverClassName);
+          return KERN_FAILURE;
+     }
+     IOObjectRelease(iterator);
+
+     // connect to service
+     kern_result = IOServiceOpen(local_driver_service, mach_task_self(), 0, &PCIDriver_connect);
+     if (kern_result != KERN_SUCCESS) {
+          fprintf(stderr, "[error] IOServiceOpen returned 0x%08x\n", kern_result);
+          return kern_result;
+     }
+
+     return KERN_SUCCESS;
 }
 
 

--- a/src/MacMSRDriver/PcmMsr/CMakeLists.txt
+++ b/src/MacMSRDriver/PcmMsr/CMakeLists.txt
@@ -26,15 +26,14 @@ target_compile_definitions(PcmMsrDriver PRIVATE
 
 target_compile_options(PcmMsrDriver PRIVATE
         "-ffreestanding"
-        "-fapple-kext"
+        "$<$<COMPILE_LANGUAGE:CXX>:-fapple-kext>"
 )
 
-target_link_libraries(PcmMsrDriver PRIVATE ${IOKIT_LIBRARY}
+target_link_libraries(PcmMsrDriver PRIVATE
         "-lkmodc++"
         "-lkmod"
         "-lcc_kext"
         "-nostdlib"
-        "-Xlinker -object_path_lto"
         "-Xlinker -export_dynamic"
         "-Xlinker -kext"
 )

--- a/src/MacMSRDriver/PcmMsr/PcmMsrClient.h
+++ b/src/MacMSRDriver/PcmMsr/PcmMsrClient.h
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2012, Intel Corporation
 // written by Austen Ott
-//    
+//
 #include <IOKit/IOService.h>
 #include <IOKit/IOUserClient.h>
 #include "PcmMsr.h"
@@ -11,24 +11,26 @@
 class PcmMsrClientClassName : public IOUserClient
 {
     OSDeclareDefaultStructors(com_intel_driver_PcmMsrClient)
-    
+
 protected:
     PcmMsrDriverClassName*                  fProvider;
     static const IOExternalMethodDispatch   sMethods[kNumberOfMethods];
-    
+
 public:
-    virtual bool start(IOService *provider);
-    
-    virtual IOReturn clientClose(void);
-    
-    virtual bool didTerminate(IOService* provider, IOOptionBits opts, bool* defer);
-    
+    virtual bool start(IOService *provider) override;
+
+    virtual IOReturn clientClose(void) override;
+
+    virtual bool didTerminate(IOService* provider, IOOptionBits opts, bool* defer) override;
+
 protected:
     IOReturn checkActiveAndOpened (const char* memberFunction);
-    
-    virtual IOReturn externalMethod(uint32_t selector, IOExternalMethodArguments* arguments,
-									IOExternalMethodDispatch* dispatch, OSObject* target, void* reference);
-    
+
+    virtual IOReturn externalMethod(uint32_t selector,
+                                    IOExternalMethodArguments* arguments,
+                                    IOExternalMethodDispatch* dispatch,
+                                    OSObject* target, void* reference) override;
+
     static IOReturn sOpenDriver(PcmMsrClientClassName* target, void* reference, IOExternalMethodArguments* args);
     virtual IOReturn openUserClient(void);
     

--- a/src/cpucounters.h
+++ b/src/cpucounters.h
@@ -61,7 +61,9 @@
 #endif
 #endif
 
+#ifdef __linux__
 #include "resctrl.h"
+#endif
 
 namespace pcm {
 


### PR DESCRIPTION
- Remove resctrl.cpp from macOS build, as it is Linux-only and ended up getting removed by the optimizer anyway (causing warnings about having no symbols when ranlib was run to create the static archive)
- Do not pass -s to linker on macOS, which is not supported
- Use kIOMainPortDefault instead of kIOMasterPortDefault for service connection, which is deprecated.
- Do not compile C files with -fapple-kext, which is only supported for C++ and Objective-C, and I missed this when adding it in a recent change
- Add override keyword to C++ methods that override superclasses, which I did not notice when adding PcmMsrClient.cpp to CMake build
