### PR TITLE
Removed custom processing of CMAKE_INSTALL_PREFIX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,12 +75,6 @@ endif(UNIX)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 
-if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT OR ${CMAKE_INSTALL_PREFIX} STREQUAL "/usr")  # default is "/usr/local", pcm default is "/usr"
-  set(CMAKE_INSTALL_PREFIX "/usr" CACHE PATH "..." FORCE)
-else()
-  set(CMAKE_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}/usr" CACHE PATH "..." FORCE)
-endif()
-
 add_subdirectory(src)
 add_subdirectory(examples)
 add_subdirectory(tests)


### PR DESCRIPTION
Replaces legacy behavior of keeping '/usr' as default install folder. New scenario - use default path (mostly /usr/local) if user didn't defined CMAKE_INSTALL_PREFIX or use this variable if user defined it.