### PR TITLE
[pcm-sensor-server] allow build on FreeBSD

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,7 +19,7 @@ if(UNIX)  # LINUX, FREE_BSD, APPLE
     endif()
 
     list(APPEND PROJECT_NAMES pcm-sensor)
-    if(LINUX)
+    if(NOT APPLE)
         list(APPEND PROJECT_NAMES pcm-sensor-server)
     endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,12 +16,9 @@ endif()
 if(UNIX)  # LINUX, FREE_BSD, APPLE
     if (NOT APPLE)
       set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS} -s")  # --strip-unneeded for packaging
+      list(APPEND PROJECT_NAMES pcm-sensor-server)
     endif()
-
     list(APPEND PROJECT_NAMES pcm-sensor)
-    if(NOT APPLE)
-        list(APPEND PROJECT_NAMES pcm-sensor-server)
-    endif()
 
     # libpcm.a
     add_library(PCM_STATIC STATIC ${COMMON_SOURCES} ${UNUX_SOURCES})


### PR DESCRIPTION
This patch allows build of pcm-sensor-server on FreeBSD. Compilation and execution are fine. 

Tested on FreeBSD VM 13.1 and FreeBSD baremetal (2xXeon Bronze 3204). Endpoint "/metrics" returns information about key metrics including UPI links