### PR TITLE
Fix 'setsockopt failed while setting timeout...'

### DIFF
--- a/src/pcm-sensor-server.cpp
+++ b/src/pcm-sensor-server.cpp
@@ -799,7 +799,7 @@ public:
 
     void setSocket( int socketFD ) {
         socketFD_ = socketFD;
-        if( 0 != socketFD )  // avoid work with 0 socket after closure socket and set value to 0
+        if( 0 == socketFD )  // avoid work with 0 socket after closure socket and set value to 0
             return;
         // When receiving the socket descriptor, set the timeout
         const auto res = setsockopt( socketFD_, SOL_SOCKET, SO_RCVTIMEO, (char*)&timeout_, sizeof(struct timeval) );


### PR DESCRIPTION
A bug introduced some time ago. Results in "setsockopt failed while setting timeout value, Socket operation on non-socket" on every closed client connection.