### PR TITLE
fix build and install issues on macos

### DIFF
--- a/src/MacMSRDriver/CMakeLists.txt
+++ b/src/MacMSRDriver/CMakeLists.txt
@@ -16,4 +16,4 @@ target_link_libraries(PcmMsr PRIVATE ${IOKIT_LIBRARY})
 add_subdirectory(PcmMsr)
 
 # Installation
-install(TARGETS PcmMsr DESTINATION "local/lib")
+install(TARGETS PcmMsr DESTINATION "lib")

--- a/src/MacMSRDriver/PcmMsr/UserKernelShared.h
+++ b/src/MacMSRDriver/PcmMsr/UserKernelShared.h
@@ -10,6 +10,11 @@
 
 #define PCM_API
 
+// kIOMainPortDefault is not supported before macOS Monterey
+#if (MAC_OS_X_VERSION_MAX_ALLOWED < 120000)
+    #define kIOMainPortDefault kIOMasterPortDefault
+#endif
+
 #include <stdint.h>
 #include "../../topologyentry.h"
 


### PR DESCRIPTION
- fix build issues before macOS Monterey. (kIOMainPortDefault is not available before macOS Monterey. Use a macro to fix that.)
- fix libPcmMsr.dylib install path, from `/usr/local/local/lib` (incorrect) to `/usr/local/lib`.