### PR TITLE
ensure PcmMsrClient can only opened by root

### DIFF
--- a/src/MacMSRDriver/PcmMsr/PcmMsrClient.cpp
+++ b/src/MacMSRDriver/PcmMsr/PcmMsrClient.cpp
@@ -41,10 +41,23 @@ IOReturn PcmMsrClientClassName::externalMethod(uint32_t selector, IOExternalMeth
 	return super::externalMethod(selector, args, dispatch, target, reference);
 }
 
+bool PcmMsrClientClassName::initWithTask(task_t owningTask, void *securityToken, UInt32 type, OSDictionary *properties)
+{
+    if(!IOUserClient::initWithTask(owningTask, securityToken, type, properties)) {
+        return false;
+    }
+    
+    sSecurityToken = securityToken;
+    return true;
+}
+
 bool PcmMsrClientClassName::start(IOService* provider)
 {
 	bool result = false;
-    
+
+    if(clientHasPrivilege(sSecurityToken, kIOClientPrivilegeAdministrator) != kIOReturnSuccess) 
+		return false;
+		
     fProvider = OSDynamicCast(PcmMsrDriverClassName, provider);
     
     if (fProvider != NULL) {

--- a/src/MacMSRDriver/PcmMsr/PcmMsrClient.h
+++ b/src/MacMSRDriver/PcmMsr/PcmMsrClient.h
@@ -14,11 +14,13 @@ class PcmMsrClientClassName : public IOUserClient
 
 protected:
     PcmMsrDriverClassName*                  fProvider;
+    void*                                   sSecurityToken;
     static const IOExternalMethodDispatch   sMethods[kNumberOfMethods];
 
 public:
+    virtual bool initWithTask(task_t owningTask, void *securityToken, UInt32 type, OSDictionary *properties) override;
     virtual bool start(IOService *provider) override;
-
+    
     virtual IOReturn clientClose(void) override;
 
     virtual bool didTerminate(IOService* provider, IOOptionBits opts, bool* defer) override;


### PR DESCRIPTION
Hi,

This is to address the concerns in #595.
Please let me if know any changes need to be made, or add, such as debug messages.

With the changes proposed executing `pcm` with other than root user will not be able to attach the driver as `IOServiceOpen` will fail.
Thanks.