### PR TITLE
Fix: Accessing member of deleted objects

### DIFF
--- a/src/windows/windriver.h
+++ b/src/windows/windriver.h
@@ -107,7 +107,8 @@ public:
                 if (err == ERROR_SERVICE_ALREADY_RUNNING) return true;
 
                 std::wcerr << "Starting MSR service failed with error " << err << " ";
-                const TCHAR * errorStr = _com_error(err).ErrorMessage();
+                const _com_error comError{ (int)err };
+                const TCHAR * errorStr = comError.ErrorMessage();
                 if (errorStr)
                     std::wcerr << errorStr << "\n";
 
@@ -120,7 +121,8 @@ public:
             else
             {
                 std::wcerr << "Opening service manager failed with error " << GetLastError() << " ";
-                const TCHAR * errorStr = _com_error(GetLastError()).ErrorMessage();
+                const _com_error comError{ (int)GetLastError() };
+                const TCHAR * errorStr = comError.ErrorMessage();
                 if (errorStr)
                     std::wcerr << errorStr << "\n";
             }
@@ -130,7 +132,8 @@ public:
         else
         {
             std::wcerr << "Opening service manager failed with error " << GetLastError() << " ";
-            const TCHAR * errorStr = _com_error(GetLastError()).ErrorMessage();
+            const _com_error comError{ (int)GetLastError() };
+            const TCHAR * errorStr = comError.ErrorMessage();
             if (errorStr)
                 std::wcerr << errorStr << "\n";
         }
@@ -169,7 +172,8 @@ public:
         else
         {
             std::wcerr << "Opening service manager failed with error " << GetLastError() << " ";
-            const TCHAR * errorStr = _com_error(GetLastError()).ErrorMessage();
+            const _com_error comError{ (int)GetLastError() };
+            const TCHAR * errorStr = comError.ErrorMessage();
             if (errorStr)
                 std::wcerr << errorStr;
         }
@@ -197,7 +201,8 @@ public:
         else
         {
             std::wcerr << "Opening service manager failed with error " << GetLastError() << " ";
-            const TCHAR * errorStr = _com_error(GetLastError()).ErrorMessage();
+            const _com_error comError{ (int)GetLastError() };
+            const TCHAR * errorStr = comError.ErrorMessage();
             if (errorStr)
                 std::wcerr << errorStr;
         }


### PR DESCRIPTION
Trying to debug pcm-pcie, program crashes when service error occures.
`_com_error::ErrorMessage()` returns a pointer, pointing to a string that will be immediately destroyed because the object was declared as an rvalue
