### PR TITLE
fix rpm.spec for non-suse rpm-based distros

### DIFF
--- a/pcm.spec
+++ b/pcm.spec
@@ -14,7 +14,12 @@ BuildRequires:   gcc
 BuildRequires:   make
 BuildRequires:   gcc-c++
 BuildRequires:   cmake
+%if 0%{?suse_version}
 BuildRequires:   libopenssl-devel
+%else
+BuildRequires:   openssl-devel
+%endif
+
 
 %description
 


### PR DESCRIPTION
Change-Id: I7ed3585ad35c731a9ac517c5e5b09b7af1ce9003