### PR TITLE
Update pcm.spec

### DIFF
--- a/pcm.spec
+++ b/pcm.spec
@@ -19,6 +19,7 @@ BuildRequires:   libopenssl-devel
 %else
 BuildRequires:   openssl-devel
 BuildRequires:   libasan
+BuildRequires:   libasan-static
 %endif
 
 


### PR DESCRIPTION
fix linking on fedora