### PR TITLE
declare service_name as TCHAR array

### DIFF
--- a/src/winpmem/winpmem.cpp
+++ b/src/winpmem/winpmem.cpp
@@ -64,8 +64,8 @@ int WinPmem::toggle_write_mode() {
 WinPmem::WinPmem():
   suppress_output(FALSE),
   fd_(INVALID_HANDLE_VALUE),
-  out_fd_(INVALID_HANDLE_VALUE),
-  service_name(PMEM_SERVICE_NAME) {
+  out_fd_(INVALID_HANDLE_VALUE) {
+  _tcscpy_s(service_name, PMEM_SERVICE_NAME);
   _tcscpy_s(last_error, TEXT(""));
   max_physical_memory_ = 0;
   }

--- a/src/winpmem/winpmem.h
+++ b/src/winpmem/winpmem.h
@@ -81,7 +81,9 @@ class WinPmem {
 
   // The file handle to the image file.
   HANDLE out_fd_;
-  TCHAR *service_name;
+  
+  // 256: The maximum length of Windows service name string.
+  TCHAR service_name[256];
   TCHAR driver_filename[MAX_PATH];
 
   // This is the maximum size of memory calculated.


### PR DESCRIPTION
const qualifier loses in WinPmem constructor.
Given its access qualifier, this could be dangerous.

Array size 256 is documented to be so, Win32 API headers did not define a macro for it. [CreateServiceW function](https://learn.microsoft.com/en-us/windows/win32/api/winsvc/nf-winsvc-createservicew#parameters)