### PR TITLE
Check for more than 1 socket before adding upi info to the dashboard

### DIFF
--- a/src/dashboard.cpp
+++ b/src/dashboard.cpp
@@ -803,6 +803,8 @@ std::string getPCMDashboardJSON(const PCMDashboardType type, int ns, int nu, int
     }
     auto upi = [&](const std::string & m, const bool utilization)
     {
+        // For UPI we need a minimum of 2 sockets
+        if ( 1 >= NumSockets ) return;
         for (size_t s = 0; s < NumSockets; ++s)
         {
             const auto S = std::to_string(s);


### PR DESCRIPTION
This should be enough to prevent UPI info from being added to the dashboard when there is only one socket