### PR TITLE
pcm-pcie: allow core offlining

### DIFF
--- a/src/pcm-pcie.h
+++ b/src/pcm-pcie.h
@@ -69,12 +69,13 @@ protected:
 void IPlatform::init()
 {
     print_cpu_details();
-
+/*
     if (m_pcm->isSomeCoreOfflined())
     {
         cerr << "Core offlining is not supported. Program aborted\n";
         exit(EXIT_FAILURE);
     }
+*/
 }
 
 IPlatform::IPlatform(PCM *m, bool csv, bool bandwidth, bool verbose) :


### PR DESCRIPTION
It seems `PCM::program()` has been checking `isCoreOnline()` since commit ["support using Linux perf API for core PMU for systems with offlined cores"](https://github.com/intel/pcm/commit/be2dbfbc24adfea956fe8d8371e6fd5d31e50a84), maybe we could consider pcm-pcie legitmate on systems with offlined cores?