### PR TITLE
pcm: allow core 0 to be offlined

### DIFF
--- a/src/cpucounters.h
+++ b/src/cpucounters.h
@@ -2304,9 +2304,9 @@ public:
     }
     //! \brief Return TSC timer value in time units
     //! \param multiplier use 1 for seconds, 1000 for ms, 1000000 for mks, etc (default is 1000: ms)
-    //! \param core core to read on-chip TSC value (default is 0)
+    //! \param core core to read on-chip TSC value (default is -1: socketRefCore[0])
     //! \return time counter value
-    uint64 getTickCount(uint64 multiplier = 1000 /* ms */, uint32 core = 0);
+    uint64 getTickCount(uint64 multiplier = 1000 /* ms */, int32 core = -1);
 
     uint64 getInvariantTSC_Fast(uint32 core = 0);
 


### PR DESCRIPTION
On servers with Intel SST-PP enabled, it seems core 0 can be put offline, and pcm will fail to start. I corrected `ref_core` from hardcoded `0` to use `socketRefCore`, and relaxed thread affinity `aff0` requirement during system topology discovery, now it works on my test environment.

Before:

```txt
$sudo ./pcm

=====  Processor information  =====
Linux arch_perfmon flag  : yes
Hybrid processor         : no
IBRS and IBPB supported  : yes
STIBP supported          : yes
Spec arch caps supported : yes
Max CPUID level          : 36
CPU family               : 6
CPU model number         : 173
ERROR: pthread_setaffinity_np for core 0 failed with code 22
PCM ERROR. Exception pthread_setaffinity_np failed
```


After:
```txt
$sudo ./pcm

=====  Processor information  =====
Linux arch_perfmon flag  : yes
Hybrid processor         : no
IBRS and IBPB supported  : yes
STIBP supported          : yes
Spec arch caps supported : yes
Max CPUID level          : 36
CPU family               : 6
CPU model number         : 173
Number of logical cores: 240

....

 Core (SKT) | UTIL | IPC  | CFREQ | L3MISS | L2MISS | L3HIT | L2HIT | L3MPI | L2MPI |   L3OCC |   LMB  |   RMB  | TEMP

   2    0     0.14   0.17   ...
   3    0     0.01   0.29   ...
   5    0     0.00   0.18   ...
   6    0     0.00   0.17   ...
   8    0     0.00   0.22   ...
   9    0     0.00   0.29   ...
```