### PR TITLE
pcm-bw-histogram.sh: expect `pcm-memory` to reside in same folder, rather than ./

### DIFF
--- a/src/pcm-bw-histogram.sh
+++ b/src/pcm-bw-histogram.sh
@@ -11,6 +11,8 @@ if [ "$#" -ne 1 ]; then
   exit 1
 fi
 
+mydir=$(dirname "$0")
+
 out=bw-tmp
 
 rm $out
@@ -18,7 +20,7 @@ rm $out
 echo
 echo ========= CHECKING FOR PMM SUPPORT =========
 echo
-./pcm-memory -pmm -- sleep 1 >tmp 2>&1
+"$mydir/pcm-memory" -pmm -- sleep 1 >tmp 2>&1
 dram_only=`cat tmp | grep "PMM traffic metrics are not available"  | wc -l`
 rm tmp
 if [ $dram_only -gt 0 ]
@@ -35,9 +37,9 @@ echo
 
 if [ $dram_only -gt 0 ]
 then
-                chrt --rr 1 nice --adjustment=-20 ./pcm-memory 0.005 -nc -csv=$out -- sleep $1
+                chrt --rr 1 nice --adjustment=-20 "$mydir/pcm-memory" 0.005 -nc -csv=$out -- sleep $1
 else
-                chrt --rr 1 nice --adjustment=-20 ./pcm-memory 0.005 -pmm -nc -csv=$out -- sleep $1
+                chrt --rr 1 nice --adjustment=-20 "$mydir/pcm-memory" 0.005 -pmm -nc -csv=$out -- sleep $1
 fi
 
 cat $out | sed 's/;/,/g' > $out.csv


### PR DESCRIPTION
As pcm-bw-histogram.sh is installed (renamed to pcm-bw-histogram) alongside the pcm-memory binary in sbin/, `pcm-memory` should be found in the same folder as the script, rather than the current folder. Without this patch, pcm-bw-histogram cannot be launched (as it cannot find ./pcm-memory), unless you cd to the sbin/ folder. This is inconvenient, as the script creates a temporary file, as well as an output .csv file, in the current folder. With this patch, you can just launch pcm-bw-histogram from any folder, and it will find pcm-memory in the same folder where it's been installed.